### PR TITLE
feat: apply sticky feature by default on mobile devices

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -30,7 +30,7 @@ In these examples the structure of the HTML uses the slot element to pull the tr
     Bottom popover content!
     <auro-button secondary id="button2" slot="trigger">Popover Test</auro-button>
   </auro-popover>
-
+  &nbsp;
   <auro-popover for="plugIcon">
     This flight offers seat power service
     <auro-icon id="plugIcon" category="in-flight" name="plug" slot="trigger"></auro-icon>
@@ -82,6 +82,7 @@ NOTE: The popover element is hidden visually, but not set to `display: none` for
   <auro-button id="button3">Popover Test</auro-button>
   <auro-popover for="button4" placement="bottom">bottom popover content!</auro-popover>
   <auro-button secondary id="button4">Popover Test</auro-button>
+  &nbsp;&nbsp;
   <auro-icon id="plugIcon2" category="in-flight" name="plug"></auro-icon>
   <auro-popover for="plugIcon2" placement="bottom">This flight offers seat power service</auro-popover>
 </div>
@@ -126,3 +127,87 @@ When the intention is to close the popover with an event within the popover, use
 ```
 
 </auro-accordion>
+
+
+## Add space around popover
+
+Depending on the element trigger that the popover element is assigned to, the spacing between the trigger and the popover may be too close. For these instances, use the `addSpace` attribute.
+
+<div class="exampleWrapper">
+  <auro-popover for="button10" addSpace>
+    Notice this popover is a little<br>further away from the trigger.
+    <auro-button id="button10" slot="trigger">Popover w/additional space</auro-button>
+  </auro-popover>
+
+  <auro-popover for="button11" placement="bottom">
+    This popover uses the default spacing<br>between the popover and the trigger.
+    <auro-button secondary id="button11" slot="trigger">Popover w/o additional space</auro-button>
+  </auro-popover>
+</div>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+```html
+<auro-popover for="button10" addSpace>
+  Notice this popover is a little<br>further away from the trigger.
+  <auro-button id="button10" slot="trigger">Popover w/additional space</auro-button>
+</auro-popover>
+
+<auro-popover for="button11" placement="bottom">
+  This popover uses the default spacing<br>between the popover and the trigger.
+  <auro-button secondary id="button11" slot="trigger">Popover w/o additional space</auro-button>
+</auro-popover>
+
+```
+</auro-accordion>
+
+## Do's and don'ts
+
+Binding a trigger event to a hyperlink is **not** recommended. This is a poor user experience for mobile devices, the event required to make the popover appear is a `tap`. The tap will also trigger the hyperlink to fire as well, thus negating the impact of the popover.
+
+The use of a hyperlink for to trigger an event in the UI is semantically incorrect and this will present itself as a confusing scenario to assistive devices.
+
+<auro-alerts error noIcon>
+
+  <div class="exampleWrapper">
+    <auro-hyperlink id="link" href="/" relative nav>hyperlink popover trigger</auro-hyperlink>
+    <auro-popover for="link">This works, but not recommended</auro-popover>
+  </div>
+
+</auro-alerts>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+```html
+<auro-hyperlink id="link" href="/" relative nav>hyperlink popover trigger</auro-hyperlink>
+<auro-popover for="link">This works, but not recommended</auro-popover>
+
+```
+</auro-accordion>
+
+In the event that a hyperlink UI is desired, it is recommended to use the `role="button"` semantic reassignment to the hyperlink element.
+
+<auro-alerts success noIcon>
+  <div class="exampleWrapper">
+    <auro-hyperlink id="linkButton" role="button" relative>hyperlink, role button</auro-hyperlink>
+    <auro-popover for="linkButton">Role button is recommended</auro-popover>
+  </div>
+</auro-alerts>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+```html
+<auro-hyperlink id="linkButton" role="button" relative>hyperlink, role button</auro-hyperlink>
+<auro-popover for="linkButton">Role button is recommended</auro-popover>
+
+```
+</auro-accordion>
+
+## Developer notes
+
+The default trigger for a popover is a `hover` event. Mobile devices do not support `hover` events directly, so the `hover` event is replaced with a `touchstart` event to produce the popover. This is to ensure reliability of the action versus versus a dependency on a secondary interruption of the `hover` event on mobile devices.
+
+The popover behaves much like the `sticky` feature on mobile devices.

--- a/demo/index.html
+++ b/demo/index.html
@@ -29,5 +29,7 @@
     <script src="https://unpkg.com/@alaskaairux/auro-accordion@latest/dist/auro-accordion__bundled.js" type="module"></script>
     <script src="https://unpkg.com/@alaskaairux/auro-button@latest/dist/auro-button__bundled.js" type="module"></script>
     <script src="https://unpkg.com/@alaskaairux/auro-icon@latest/dist/auro-icon__bundled.js" type="module"></script>
+    <script src="https://unpkg.com/@alaskaairux/auro-hyperlink@latest/dist/auro-hyperlink__bundled.js" type="module"></script>
+    <script src="https://unpkg.com/@alaskaairux/auro-alerts@latest/dist/auro-alerts__bundled.js" type="module"></script>
   </body>
 </html>

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,12 @@
 
 Popover attaches to an element and displays on hover/blur.
 
+## Attributes
+
+| Attribute  | Type      | Description                                      |
+|------------|-----------|--------------------------------------------------|
+| `addSpace` | `boolean` | If true, will add additional top and bottom space around the appearance of the popover in relation to the trigger.. |
+
 ## Properties
 
 | Property    | Attribute   | Type      | Default | Description                                      |

--- a/src/auro-popover.js
+++ b/src/auro-popover.js
@@ -17,6 +17,7 @@ import Popover from "./popover";
  * @attr {String} placement - Expects top/bottom - position for popover in relation to the element.
  * @attr {String} for - Defines an `id` for an element in the DOM to trigger on hover/blur.
  * @attr {boolean} sticky - If true, popover will persist its visibility when clicked.
+ * @attr {boolean} addSpace - If true, will add additional top and bottom space around the appearance of the popover in relation to the trigger..
  * @slot - Default unnamed slot for the use of popover content
  * @slot trigger - Slot for entering the trigger element into the scope of the shadow DOM
  */
@@ -27,6 +28,12 @@ class AuroPopover extends LitElement {
     this.privateDefaults();
 
     this.placement = 'top';
+
+    // adds toggle function to root element based on touch
+    this.addEventListener('touchstart', function() {
+      this.toggleShow();
+      this.setAttribute("isTouch", "true");
+    });
   }
 
   /**
@@ -77,16 +84,20 @@ class AuroPopover extends LitElement {
     this.popper = new Popover(this.trigger, this.popover, this.placement);
 
     const handleShow = () => {
-        this.toggleShow();
-      },
-      handleHide = () => {
+      this.toggleShow();
+    },
+    handleHide = () => {
+      this.toggleHide();
+    },
+    handleTabWhenFocusOnTrigger = (event) => {
+      if (event.key.toLowerCase() === 'tab') {
         this.toggleHide();
-      },
-      handleTabWhenFocusOnTrigger = (event) => {
-        if (event.key.toLowerCase() === 'tab') {
-          this.toggleHide();
-        }
-      };
+      }
+    };
+
+    if (!this.sticky) {
+      this.trigger.addEventListener('touchstart', handleShow);
+    }
 
     if (this.sticky) {
       this.trigger.addEventListener('click', handleShow);
@@ -141,6 +152,7 @@ class AuroPopover extends LitElement {
         <div id="arrow" class="arrow" data-popper-arrow></div>
         <slot role="tooltip"></slot>
       </div>
+
       <slot name="trigger"></slot>
     `;
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -21,6 +21,12 @@ $auro-inset-directions:'';
   cursor: pointer;
 }
 
+:host([addSpace]) {
+  .popover {
+    margin: 1rem 0 !important;
+  }
+}
+
 .popover {
   border-radius: var(--auro-border-radius);
   background: var(--auro-color-background-lightest);


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #11 

## Summary:

The scope of this update is to address a better and consistent experience with mobile devices. The primary trigger of a popover is a `hover` event. This is not directly supported on mobile devices and there is a secondary response of supporting the `hover` event by tapping on the trigger. This is not intentional and feels unreliable. 

To address this, the update is designed to recognize a touch event, replacing the hover event with a touch to produce the popover. 

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
