### PR TITLE
fix: find trigger in another shadow root

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "ignorePatterns": ["test/*.js", ".eslintrc.js"],
   "env": {
       "browser": true,
       "es6": true

--- a/src/auro-popover.js
+++ b/src/auro-popover.js
@@ -69,6 +69,11 @@ class AuroPopover extends LitElement {
 
   firstUpdated() {
     this.trigger = document.querySelector(`#${this.for}`);
+    // allow placement in shadow roots
+    if (this.trigger === null) {
+      this.trigger = this.getRootNode().querySelector(`#${this.for}`);
+    }
+
     this.popover = this.shadowRoot.querySelector('#popover');
     this.popper = new Popover(this.trigger, this.popover, this.placement);
 

--- a/test/auro-popover.test.js
+++ b/test/auro-popover.test.js
@@ -1,5 +1,6 @@
 import { fixture, html, expect } from '@open-wc/testing';
 import '../src/auro-popover.js';
+import './shadow-popover';
 
 describe('auro-popover', () => {
   it('is accessible', async () => {
@@ -15,6 +16,14 @@ describe('auro-popover', () => {
     const el = await Boolean(customElements.get("auro-popover"));
 
     await expect(el).to.be.true;
+  });
+
+  it('finds trigger in shadow root', async () => {
+    const el = await fixture(html`
+      <shadow-popover></shadow-popover>
+    `);
+
+    expect(el.popover.trigger).to.eql(el.trigger);
   });
 
   describe('visibility via mouse', () => {

--- a/test/shadow-popover.js
+++ b/test/shadow-popover.js
@@ -1,0 +1,23 @@
+import "../src/auro-popover";
+import { html, LitElement } from "lit-element";
+
+class ShadowPopover extends LitElement {
+  get popover() {
+    return this.shadowRoot.querySelector('auro-popover');
+  }
+
+  get trigger() {
+    return this.shadowRoot.querySelector('button');
+  }
+
+  render() {
+    return html`
+      <auro-popover for="shadowTest">
+        Popover text
+        <button id="shadowTest" slot="trigger">Details</button>
+      </auro-popover>
+    `;
+  }
+}
+
+customElements.define('shadow-popover', ShadowPopover);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #29

## Summary:

This PR allows the popover to be placed inside another shadow root. This is needed due to a regression introduced by https://github.com/AlaskaAirlines/auro-popover/pull/13/commits/c3cec834804e103513df285b5ca2b6d5d0be7acf.

If the trigger can be queried from the document, we use that. Otherwise, we get the shadow root using [`getRootNode`](https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode) and query there.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
