### PR TITLE
feat: fallback to slotted trigger when query fails #28

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -128,7 +128,7 @@ module.exports = {
       "no-lone-blocks": "error",
       "no-lonely-if": "error",
       "no-loop-func": "error",
-      "no-magic-numbers": "error",
+      "no-magic-numbers": ["error", { "ignore": [0] }],
       "no-mixed-operators": "error",
       "no-mixed-requires": "error",
       "no-multi-assign": "error",

--- a/demo/demo.md
+++ b/demo/demo.md
@@ -19,14 +19,19 @@ Auro popover allows two ways to layout the HTML. Please see the following exampl
 The following examples illustrates using the `trigger` slot within the scope of the `auro-popover` element.
 
 <div class="exampleWrapper" style="overflow: unset">
-  <auro-popover for="button1">
+  <auro-popover>
     Top popover content!
-    <auro-button id="button1" slot="trigger">Popover Test</auro-button>
+    <auro-button slot="trigger">Popover Test</auro-button>
   </auro-popover>
 
-  <auro-popover for="button2" placement="bottom">
+  <auro-popover placement="bottom">
     Bottom popover content!
-    <auro-button secondary id="button2" slot="trigger">Popover Test</auro-button>
+    <auro-button secondary slot="trigger">Popover Test</auro-button>
+  </auro-popover>
+
+  <auro-popover for="button1">
+    Bottom popover content!
+    <auro-button id="button1" slot="trigger">Popover Test</auro-button>
   </auro-popover>
 </div>
 
@@ -35,15 +40,21 @@ The following examples illustrates using the `trigger` slot within the scope of 
 
 ```html
 <!-- The slot=trigger attribute is bound directly to the auro-button element  -->
-<auro-popover for="button1">
+<auro-popover>
   Top popover content!
-  <auro-button id="button1" slot="trigger">Popover Test</auro-button>
+  <auro-button slot="trigger">Popover Test</auro-button>
 </auro-popover>
 
 <!-- Using the placement=bottom attribute -->
-<auro-popover for="button2" placement="bottom">
+<auro-popover placement="bottom">
   Bottom popover content!
-  <auro-button secondary id="button2" slot="trigger">Popover Test</auro-button>
+  <auro-button secondary slot="trigger">Popover Test</auro-button>
+</auro-popover>
+
+<!-- Using explicit for and id attributes -->
+<auro-popover for="button1">
+  More popover content!
+  <auro-button id="button1" slot="trigger">Popover Test</auro-button>
 </auro-popover>
 ```
 </auro-accordion>
@@ -53,14 +64,14 @@ The following examples illustrates using the `trigger` slot within the scope of 
 Sometimes you just need more space. For these instances, use the `addSpace` attribute.
 
 <div class="exampleWrapper" style="overflow: unset">
-  <auro-popover for="button10" addSpace>
+  <auro-popover addSpace>
     Notice this popover is a little<br>further away from the trigger.
-    <auro-button id="button10" slot="trigger">Popover w/additional space above</auro-button>
+    <auro-button slot="trigger">Popover w/additional space above</auro-button>
   </auro-popover>
 
-  <auro-popover for="button11" placement="bottom" addSpace>
+  <auro-popover placement="bottom" addSpace>
     Notice this popover is a little<br>further away from the trigger.
-    <auro-button secondary id="button11" slot="trigger">Popover w/additional space below</auro-button>
+    <auro-button secondary slot="trigger">Popover w/additional space below</auro-button>
   </auro-popover>
 </div>
 
@@ -68,14 +79,14 @@ Sometimes you just need more space. For these instances, use the `addSpace` attr
   <span slot="trigger">See code</span>
 
 ```html
-<auro-popover for="button10" addSpace>
+<auro-popover addSpace>
   Notice this popover is a little<br>further away from the trigger.
-  <auro-button id="button10" slot="trigger">Popover w/additional space above</auro-button>
+  <auro-button slot="trigger">Popover w/additional space above</auro-button>
 </auro-popover>
 
-<auro-popover for="button11" placement="bottom" addSpace>
+<auro-popover placement="bottom" addSpace>
   Notice this popover is a little<br>further away from the trigger.
-  <auro-button secondary id="button11" slot="trigger">Popover w/additional space below</auro-button>
+  <auro-button secondary slot="trigger">Popover w/additional space below</auro-button>
 </auro-popover>
 
 ```
@@ -87,9 +98,9 @@ Sometimes you just need less space. For these instances, use the `removeSpace` a
 
 <div class="exampleWrapper">
   <!-- The slot=trigger attribute is bound directly to the auro-icon element  -->
-  <auro-popover for="plugIcon" removeSpace>
+  <auro-popover removeSpace>
     Notice this popover is a little<br>closer to the trigger.
-    <auro-icon id="plugIcon" category="in-flight" name="plug" slot="trigger" tabindex="0"></auro-icon>
+    <auro-icon category="in-flight" name="plug" slot="trigger" tabindex="0"></auro-icon>
   </auro-popover>
 </div>
 
@@ -98,7 +109,7 @@ Sometimes you just need less space. For these instances, use the `removeSpace` a
 
 ```html
 <!-- The slot=trigger attribute is bound directly to the auro-icon element  -->
-<auro-popover for="plugIcon" removeSpace>
+<auro-popover removeSpace>
   Notice this popover is a little<br>closer to the trigger.
 
     <!--
@@ -106,7 +117,7 @@ Sometimes you just need less space. For these instances, use the `removeSpace` a
       be sure to add `tabindex="0"` to the element when using `auro-popover`
       otherwise users of assistive technology will not see the content.
     -->
-  <auro-icon id="plugIcon" category="in-flight" name="plug" slot="trigger" tabindex="0"></auro-icon>
+  <auro-icon category="in-flight" name="plug" slot="trigger" tabindex="0"></auro-icon>
 </auro-popover>
 ```
 </auro-accordion>
@@ -121,9 +132,9 @@ The use of a hyperlink for to trigger an event in the UI is semantically incorre
 
 <auro-alerts error noIcon>
   <div class="exampleWrapper">
-    <auro-popover for="link">
+    <auro-popover>
       This works, but not recommended
-      <auro-hyperlink id="link" href="#" relative nav slot="trigger">hyperlink popover trigger</auro-hyperlink>
+      <auro-hyperlink href="#" relative nav slot="trigger">hyperlink popover trigger</auro-hyperlink>
     </auro-popover>
   </div>
 </auro-alerts>
@@ -132,9 +143,9 @@ The use of a hyperlink for to trigger an event in the UI is semantically incorre
   <span slot="trigger">See code</span>
 
 ```html
-<auro-popover for="link">
+<auro-popover>
   This works, but not recommended
-  <auro-hyperlink id="link" href="#" relative nav slot="trigger">hyperlink popover trigger</auro-hyperlink>
+  <auro-hyperlink href="#" relative nav slot="trigger">hyperlink popover trigger</auro-hyperlink>
 </auro-popover>
 ```
 </auro-accordion>
@@ -143,9 +154,9 @@ In the event that a hyperlink UI is desired, it is recommended to use the `role=
 
 <auro-alerts success noIcon>
   <div class="exampleWrapper">
-    <auro-popover for="linkButton">
+    <auro-popover>
       Role button is recommended
-      <auro-hyperlink id="linkButton" role="button" slot="trigger">hyperlink, role button</auro-hyperlink>
+      <auro-hyperlink role="button" slot="trigger">hyperlink, role button</auro-hyperlink>
     </auro-popover>
   </div>
 </auro-alerts>
@@ -154,9 +165,9 @@ In the event that a hyperlink UI is desired, it is recommended to use the `role=
   <span slot="trigger">See code</span>
 
 ```html
-<auro-popover for="linkButton">
+<auro-popover>
   Role button is recommended
-  <auro-hyperlink id="linkButton" role="button" slot="trigger">hyperlink, role button</auro-hyperlink>
+  <auro-hyperlink role="button" slot="trigger">hyperlink, role button</auro-hyperlink>
 </auro-popover>
 ```
 </auro-accordion>

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,7 @@ Popover attaches to an element and displays on hover/blur.
 
 | Property    | Attribute   | Type     | Default | Description                                      |
 |-------------|-------------|----------|---------|--------------------------------------------------|
-| `for`       | `for`       | `String` |         | Defines an `id` for an element in the DOM to trigger on hover/blur |
+| `for`       | `for`       | `String` |         | Directly associate the popover with a trigger element with the given ID. In most cases, this should not be necessary and set slot="trigger" on the element instead. |
 | `placement` | `placement` | `String` | "top"   | Expects top/bottom - position for popover in relation to the element |
 
 ## Slots
@@ -21,4 +21,4 @@ Popover attaches to an element and displays on hover/blur.
 | Name      | Description                                      |
 |-----------|--------------------------------------------------|
 |           | Default unnamed slot for the use of popover content |
-| `trigger` | Slot for entering the trigger element into the scope of the shadow DOM |
+| `trigger` | The element in this slot triggers hiding and showing the popover. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-popover",
-  "version": "1.5.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auro-popover.js
+++ b/src/auro-popover.js
@@ -68,10 +68,13 @@ class AuroPopover extends LitElement {
   }
 
   firstUpdated() {
-    this.trigger = document.querySelector(`#${this.for}`);
-    // allow placement in shadow roots
-    if (this.trigger === null) {
-      this.trigger = this.getRootNode().querySelector(`#${this.for}`);
+    if (this.for) {
+      this.trigger = document.querySelector(`#${this.for}`) ||
+        this.getRootNode().querySelector(`#${this.for}`);
+    }
+
+    if (!this.trigger) {
+      [this.trigger] = this.shadowRoot.querySelector('slot[name="trigger"]').assignedElements();
     }
 
     this.popover = this.shadowRoot.querySelector('#popover');

--- a/src/auro-popover.js
+++ b/src/auro-popover.js
@@ -15,11 +15,11 @@ import Popover from "./popover";
  * Popover attaches to an element and displays on hover/blur.
  *
  * @attr {String} placement - Expects top/bottom - position for popover in relation to the element
- * @attr {String} for - Defines an `id` for an element in the DOM to trigger on hover/blur
+ * @attr {String} for - Directly associate the popover with a trigger element with the given ID. In most cases, this should not be necessary and set slot="trigger" on the element instead.
  * @attr {boolean} addSpace - If true, will add additional top and bottom space around the appearance of the popover in relation to the trigger
  * @attr {boolean} removeSpace - If true, will remove top and bottom space around the appearance of the popover in relation to the trigger
  * @slot - Default unnamed slot for the use of popover content
- * @slot trigger - Slot for entering the trigger element into the scope of the shadow DOM
+ * @slot trigger - The element in this slot triggers hiding and showing the popover.
  */
 class AuroPopover extends LitElement {
   constructor() {

--- a/test/auro-popover.test.js
+++ b/test/auro-popover.test.js
@@ -18,15 +18,7 @@ describe('auro-popover', () => {
     await expect(el).to.be.true;
   });
 
-  it('finds trigger in shadow root', async () => {
-    const el = await fixture(html`
-      <shadow-popover></shadow-popover>
-    `);
-
-    expect(el.popover.trigger).to.eql(el.trigger);
-  });
-
-  it('finds trigger without id and for attributes', async () => {
+  it('finds trigger in slot', async () => {
     const el = await fixture(html`
       <auro-popover>
         tooltip text
@@ -38,7 +30,39 @@ describe('auro-popover', () => {
     expect(el.trigger).to.eql(button);
   });
 
-  it('falls back to slot trigger when no element with given id', async () => {
+  it('finds trigger with id and for attributes', async () => {
+    const el = await fixture(html`
+      <auro-popover for="popover1">
+        tooltip text
+        <auro-button id="popover1" slot="trigger">trigger text</auro-button>
+      </auro-popover>
+    `);
+
+    const trigger = el.querySelector('auro-button');
+    expect(el.trigger).to.eql(trigger);
+  })
+
+  it('finds trigger in shadow root using for attribute', async () => {
+    const el = await fixture(html`
+      <shadow-popover></shadow-popover>
+    `);
+
+    expect(el.popover.trigger).to.eql(el.trigger);
+  });
+
+  it('finds trigger in slot', async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <auro-button slot="trigger">trigger text</auro-button>
+      </auro-popover>
+    `);
+    const button = el.querySelector('auro-button');
+
+    expect(el.trigger).to.eql(button);
+  });
+
+  it('falls back to slot trigger when for attribute set but no element with given id', async () => {
     // this test case is for frameworks like Svelte, where id could be set as a property on a custom element
     const el = await fixture(html`
       <auro-popover for="test">
@@ -149,9 +173,9 @@ describe('auro-popover', () => {
 async function getFixture() {
   return await fixture (
     html`
-      <auro-popover for="popover1">
+      <auro-popover>
         tooltip text
-        <auro-button id="popover1" slot="trigger">trigger text</auro-button>
+        <auro-button slot="trigger">trigger text</auro-button>
       </auro-popover>
     `);
 }

--- a/test/auro-popover.test.js
+++ b/test/auro-popover.test.js
@@ -26,6 +26,31 @@ describe('auro-popover', () => {
     expect(el.popover.trigger).to.eql(el.trigger);
   });
 
+  it('finds trigger without id and for attributes', async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <auro-button slot="trigger">trigger text</auro-button>
+      </auro-popover>
+    `);
+    const button = el.querySelector('auro-button');
+
+    expect(el.trigger).to.eql(button);
+  });
+
+  it('falls back to slot trigger when no element with given id', async () => {
+    // this test case is for frameworks like Svelte, where id could be set as a property on a custom element
+    const el = await fixture(html`
+      <auro-popover for="test">
+        tooltip text
+        <auro-button slot="trigger">trigger text</auro-button>
+      </auro-popover>
+    `);
+    const button = el.querySelector('auro-button');
+
+    expect(el.trigger).to.eql(button);
+  });
+
   describe('visibility via mouse', () => {
     it('shows hidden content on hover', async () => {
       const el = await getFixture();


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #28

## Summary:

When auro-button was used as the popover trigger in a Svelte application, the trigger would not be initialized properly. This is because the button `id` was being set as a property, so `querySelector` didn't work. 

At first I tried reflecting `id` to an attribute on `auro-button` so that `querySelector` could find it, but that was not reflected by the button until after popover had initialized the trigger, and the same problem occurred.

Instead, I chose to get the node assigned to the trigger slot, and use that if we couldn't find the trigger using `querySelector`. It could be possible to use this as our primary method of finding the trigger; however, I wasn't 100% confident that this wouldn't break existing uses of popover.

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
