### PR TITLE
fix: fixed issue related to onDark being overwritten #108

### DIFF
--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -8,7 +8,8 @@
 /* stylelint-disable scss/dollar-variable-empty-line-before, at-rule-empty-line-before, order/properties-order, scss/selector-nest-combinators, declaration-empty-line-before, 
    scss/at-extend-no-missing-placeholder,  declaration-no-important, selector-max-combinators, selector-max-compound-selectors, no-descending-specificity, color-function-notation */
 
-::slotted(*):not([onDark]) {
+::slotted(*):not([onDark]),
+::slotted(*):not([appearance="inverse"]) {
   color: var(--ds-auro-popover-text-color);
 }
 

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -8,7 +8,7 @@
 /* stylelint-disable scss/dollar-variable-empty-line-before, at-rule-empty-line-before, order/properties-order, scss/selector-nest-combinators, declaration-empty-line-before, 
    scss/at-extend-no-missing-placeholder,  declaration-no-important, selector-max-combinators, selector-max-compound-selectors, no-descending-specificity, color-function-notation */
 
-::slotted(*) {
+::slotted(*):not([onDark]) {
   color: var(--ds-auro-popover-text-color);
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Prevent onDark attribute from being overridden by adding :not([onDark]) to the ::slotted selector in color.scss