### PR TITLE
RC 2025-10-29

### DIFF
--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -8,7 +8,8 @@
 /* stylelint-disable scss/dollar-variable-empty-line-before, at-rule-empty-line-before, order/properties-order, scss/selector-nest-combinators, declaration-empty-line-before, 
    scss/at-extend-no-missing-placeholder,  declaration-no-important, selector-max-combinators, selector-max-compound-selectors, no-descending-specificity, color-function-notation */
 
-::slotted(*):not([onDark]) {
+::slotted(*):not([onDark]),
+::slotted(*):not([appearance="inverse"]) {
   color: var(--ds-auro-popover-text-color);
 }
 

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -8,7 +8,7 @@
 /* stylelint-disable scss/dollar-variable-empty-line-before, at-rule-empty-line-before, order/properties-order, scss/selector-nest-combinators, declaration-empty-line-before, 
    scss/at-extend-no-missing-placeholder,  declaration-no-important, selector-max-combinators, selector-max-compound-selectors, no-descending-specificity, color-function-notation */
 
-::slotted(*) {
+::slotted(*):not([onDark]) {
   color: var(--ds-auro-popover-text-color);
 }
 


### PR DESCRIPTION
## RC Summary

- chore da52470 | 2025-10-16 | Alexis Bolaños Avalos
chore: add :not([appearance='inverse']) to avoid overwrite

- fix 9bbf94b | 2025-10-16 | Alexis Bolaños Avalos
fix: fixed issue related to onDark being overwritten #108

## Summary by Sourcery

Refine the ::slotted color styling to avoid overwriting dark-mode and inverse appearance elements

Bug Fixes:
- Prevent elements with the onDark attribute from having their color overwritten by the slotted selector

Enhancements:
- Add exclusion for elements with appearance="inverse" to the slotted selector to avoid style overrides