### PR TITLE
Update popover a11y behavior

### DIFF
--- a/demo/api.md
+++ b/demo/api.md
@@ -7,14 +7,15 @@ The `auro-popover` element attaches to another element and displays on hover.
 
 ### Properties & Attributes
 
-| Properties  | Attributes  | Modifiers | Type             | Default | Description                                                                                                                                                            |
-| ----------- | ----------- | --------- | ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| addSpace    | addSpace    |           | boolean          |         | Adds additional top and bottom space around the appearance of the popover in relation to the trigger.                                                                  |
-| boundary    | boundary    |           | string \| object |         | The element to use as the boundary for the popover. Can be a query selector or an HTML element.                                                                        |
-| disabled    | disabled    |           | boolean          |         | Disables the popover from showing on hover and focus.                                                                                                                  |
-| for         | for         |           | string           |         | Directly associates the popover with a trigger element with the given ID. In most cases, this should not be necessary and set `slot="trigger"` on the element instead. |
-| placement   | placement   |           | string           | `top`   | Position for popover in relation to the element {'top' \| 'bottom'}.                                                                                                   |
-| removeSpace | removeSpace |           | boolean          |         | Removes top and bottom space around the appearance of the popover in relation to the trigger.                                                                          |
+| Properties  | Attributes  | Modifiers | Type             | Default | Description                                                                                                                                                                                                        |
+| ----------- | ----------- | --------- | ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| addSpace    | addSpace    |           | boolean          |         | Adds additional top and bottom space around the appearance of the popover in relation to the trigger.                                                                                                              |
+| boundary    | boundary    |           | string \| object |         | The element to use as the boundary for the popover. Can be a query selector or an HTML element.                                                                                                                    |
+| disabled    | disabled    |           | boolean          |         | Disables the popover from showing on hover and focus.                                                                                                                                                              |
+| for         | for         |           | string           |         | Directly associates the popover with a trigger element with the given ID. In most cases, this should not be necessary and set `slot="trigger"` on the element instead.                                             |
+| placement   | placement   |           | string           | `top`   | Position for popover in relation to the element {'top' \| 'bottom'}.                                                                                                                                               |
+| removeSpace | removeSpace |           | boolean          |         | Removes top and bottom space around the appearance of the popover in relation to the trigger.                                                                                                                      |
+|             | data-show   |           | boolean          | `false` | Whether the popover is currently visible. Reflected as the `data-show`<br>attribute so host-level CSS selectors (e.g. `:host([data-show])`) work.<br>Also drives `aria-hidden` on the popover div in the template. |
 
 ### Methods
 
@@ -59,7 +60,9 @@ The `auro-popover` element attaches to another element and displays on hover.
 
 The trigger can be any element, not just buttons or links. The component automatically makes any non-focusable trigger keyboard accessible — including custom elements like `auro-icon` that have no internal focusable element. For icon-based triggers without visible text, `aria-label` is still required to provide an accessible name.
 
-> **Accessibility note:** `auro-popover` manages `aria-description` on the trigger element as part of its accessibility contract — the popover content becomes the trigger's accessible description so screen readers can announce it on focus. Any existing `aria-description` on the trigger will be replaced when the component connects and removed when it disconnects.
+> **Accessibility note:** `auro-popover` manages `aria-description` on the focusable element(s) within the trigger slot as part of its accessibility contract — the popover content becomes the trigger's accessible description so screen readers can announce it on focus. When the trigger is a non-focusable wrapper around focusable content (e.g. `<div><a href="#">link</a></div>`), the description is applied to each focusable descendant rather than the wrapper itself. Any existing `aria-description` on affected elements will be replaced when the component connects and removed when it disconnects.
+>
+> **Keyboard behavior:** Non-interactive triggers (e.g. `<abbr>`, `<auro-icon>`) are automatically made keyboard accessible with `tabindex="0"`. `Space` and `Enter` toggle the popover open and closed, ensuring keyboard-only users have parity with mouse/hover users. This is intentional — accessibility covers more than screen readers, and without activation semantics a keyboard-only user has no way to interact with a non-interactive trigger.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/non-interactive-triggers.html) -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,14 +4,15 @@ The `auro-popover` element attaches to another element and displays on hover.
 
 ### Properties & Attributes
 
-| Properties  | Attributes  | Modifiers | Type             | Default | Description                                                                                                                                                            |
-| ----------- | ----------- | --------- | ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| addSpace    | addSpace    |           | boolean          |         | Adds additional top and bottom space around the appearance of the popover in relation to the trigger.                                                                  |
-| boundary    | boundary    |           | string \| object |         | The element to use as the boundary for the popover. Can be a query selector or an HTML element.                                                                        |
-| disabled    | disabled    |           | boolean          |         | Disables the popover from showing on hover and focus.                                                                                                                  |
-| for         | for         |           | string           |         | Directly associates the popover with a trigger element with the given ID. In most cases, this should not be necessary and set `slot="trigger"` on the element instead. |
-| placement   | placement   |           | string           | `top`   | Position for popover in relation to the element {'top' \| 'bottom'}.                                                                                                   |
-| removeSpace | removeSpace |           | boolean          |         | Removes top and bottom space around the appearance of the popover in relation to the trigger.                                                                          |
+| Properties  | Attributes  | Modifiers | Type             | Default | Description                                                                                                                                                                                                        |
+| ----------- | ----------- | --------- | ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| addSpace    | addSpace    |           | boolean          |         | Adds additional top and bottom space around the appearance of the popover in relation to the trigger.                                                                                                              |
+| boundary    | boundary    |           | string \| object |         | The element to use as the boundary for the popover. Can be a query selector or an HTML element.                                                                                                                    |
+| disabled    | disabled    |           | boolean          |         | Disables the popover from showing on hover and focus.                                                                                                                                                              |
+| for         | for         |           | string           |         | Directly associates the popover with a trigger element with the given ID. In most cases, this should not be necessary and set `slot="trigger"` on the element instead.                                             |
+| placement   | placement   |           | string           | `top`   | Position for popover in relation to the element {'top' \| 'bottom'}.                                                                                                                                               |
+| removeSpace | removeSpace |           | boolean          |         | Removes top and bottom space around the appearance of the popover in relation to the trigger.                                                                                                                      |
+|             | data-show   |           | boolean          | `false` | Whether the popover is currently visible. Reflected as the `data-show`<br>attribute so host-level CSS selectors (e.g. `:host([data-show])`) work.<br>Also drives `aria-hidden` on the popover div in the template. |
 
 ### Methods
 

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -20,7 +20,7 @@
 
 The trigger can be any element, not just buttons or links. The component automatically makes any non-focusable trigger keyboard accessible — including custom elements like `auro-icon` that have no internal focusable element. For icon-based triggers without visible text, `aria-label` is still required to provide an accessible name.
 
-> **Accessibility note:** `auro-popover` manages `aria-description` on the trigger element as part of its accessibility contract — the popover content becomes the trigger's accessible description so screen readers can announce it on focus. Any existing `aria-description` on the trigger will be replaced when the component connects and removed when it disconnects.
+> **Accessibility note:** `auro-popover` manages `aria-description` on the focusable element(s) within the trigger slot as part of its accessibility contract — the popover content becomes the trigger's accessible description so screen readers can announce it on focus. When the trigger is a non-focusable wrapper around focusable content (e.g. `<div><a href="#">link</a></div>`), the description is applied to each focusable descendant rather than the wrapper itself. Any existing `aria-description` on affected elements will be replaced when the component connects and removed when it disconnects.
 >
 > **Keyboard behavior:** Non-interactive triggers (e.g. `<abbr>`, `<auro-icon>`) are automatically made keyboard accessible with `tabindex="0"`. `Space` and `Enter` toggle the popover open and closed, ensuring keyboard-only users have parity with mouse/hover users. This is intentional — accessibility covers more than screen readers, and without activation semantics a keyboard-only user has no way to interact with a non-interactive trigger.
 

--- a/docs/why-popover.md
+++ b/docs/why-popover.md
@@ -1,0 +1,70 @@
+# Why auro-popover over native browser tooltips
+
+The native `title` attribute provides a basic tooltip, but it falls short in accessibility, customization, and interaction design. `auro-popover` addresses each of these gaps.
+
+## Rich HTML content
+
+Native tooltips render plain text only. `auro-popover` accepts any slotted HTML — formatted text, links, icons, or any other markup — giving authors full control over what appears in the popover.
+
+## Accessibility
+
+Native `title` tooltips have well-documented accessibility problems. Screen readers handle them inconsistently, they cannot be reached by keyboard, and there is no standardized way to control when or how they are announced.
+
+`auro-popover` takes a different approach:
+
+- **aria-description (ARIA 1.3)** is set on the element that actually receives focus, so screen readers reliably announce the popover content. When the trigger is a wrapper around focusable children (e.g. `<div><a href="#">…</a></div>`) or a custom element with shadow DOM, the description is placed on the correct inner target — not on a container the user never focuses.
+- **aria-hidden** on the popover container is synchronized with visibility state, so content is hidden from the accessibility tree when the popover is closed and exposed when open.
+- **Auto-tabindex** is added to non-focusable trigger elements (like `<span>` or `<abbr>`) so they can be reached by keyboard without requiring the author to add `tabindex` manually. Elements that are already focusable — natively or through shadow DOM — are left alone to avoid creating double tab stops.
+- **role="none"** on the host element prevents screen readers from announcing the custom element wrapper as an extra group.
+
+## Keyboard navigation
+
+Native tooltips have no keyboard interaction. `auro-popover` supports:
+
+- **Space / Enter** to toggle visibility (only on the trigger element itself, not on interactive descendants inside a wrapper trigger)
+- **Escape** to dismiss
+- **Tab** to dismiss and move to the next focusable element
+
+When the trigger is a wrapper element containing interactive children (e.g. `<button slot="trigger">click me</button>`), Space and Enter on the inner element activate that element's native behavior rather than toggling the popover. The popover can be dismissed with Escape or Tab in this pattern.
+
+## Touch support
+
+On touch devices, hover is unreliable or unavailable. `auro-popover` listens for `touchstart` to toggle the popover, giving mobile and tablet users the same access to popover content.
+
+## Intelligent positioning
+
+Native tooltip placement is entirely browser-controlled and cannot be configured. `auro-popover` uses Popper.js to provide:
+
+- **Configurable placement** — `top` (default) or `bottom` relative to the trigger.
+- **Overflow prevention** — the popover automatically repositions to stay within the viewport or a custom boundary element.
+- **Boundary control** — the `boundary` property accepts a CSS selector or an element reference to constrain where the popover can appear, which is critical inside modals or scrollable containers.
+
+## Styling and theming
+
+Native tooltips use browser-default styling that cannot be changed. `auro-popover` integrates with the Auro Design System through CSS custom properties:
+
+| Token | Purpose |
+|-------|---------|
+| `--ds-auro-popover-container-color` | Background color |
+| `--ds-auro-popover-text-color` | Text color |
+| `--ds-auro-popover-boxshadow-color` | Box shadow |
+
+The `::part(popover)` CSS part is also exported for direct style customization. Spacing between the popover and its trigger can be adjusted with the `addSpace` and `removeSpace` attributes.
+
+## Disabled state
+
+Setting the `disabled` attribute prevents the popover from appearing on hover, focus, or keyboard input. If the popover is already visible when `disabled` is set, it is automatically hidden and all side effects (Popper positioning, body listeners, aria-hidden) are cleaned up consistently.
+
+## Flexible trigger resolution
+
+Triggers can be defined by slotting an element with `slot="trigger"`, or by referencing an element ID with the `for` attribute. This supports triggers that live outside the popover's immediate DOM tree, including elements inside other shadow roots.
+
+## Dynamic content synchronization
+
+When popover slot content changes after initial render, `aria-description` is automatically updated on all associated focusable targets. Native `title` attributes require manual re-setting if content changes.
+
+**Known limitation:** When the trigger is a custom element without `delegatesFocus` whose shadow DOM contains focusable elements, `aria-description` is set directly on those internal shadow DOM elements. If the custom element re-renders (e.g. a Lit component updating its template), the `aria-description` attribute may be lost. Auro components use `delegatesFocus` and are not affected by this limitation.
+
+## Lifecycle management
+
+`auro-popover` handles its own teardown — removing event listeners, cleaning up `aria-description` and auto-added `tabindex`, detaching global listeners, and destroying the Popper instance — so there is no risk of stale accessibility state or memory leaks when the component is removed from the DOM.

--- a/src/auro-popover.js
+++ b/src/auro-popover.js
@@ -23,6 +23,7 @@ export class AuroPopover extends LitElement {
     super();
 
     this.placement = "top";
+    this.isPopoverVisible = false;
 
     // Stable event-listener references used across the component lifecycle.
     this._onTouchStart = null;
@@ -43,7 +44,6 @@ export class AuroPopover extends LitElement {
    * @returns {void}
    */
   _initializeDefaults() {
-    this.isPopoverVisible = false;
     this.runtimeUtils = new AuroLibraryRuntimeUtils();
   }
 
@@ -94,6 +94,22 @@ export class AuroPopover extends LitElement {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * Whether the popover is currently visible. Reflected as the `data-show`
+       * attribute so host-level CSS selectors (e.g. `:host([data-show])`) work.
+       * Also drives `aria-hidden` on the popover div in the template.
+       * @private
+       */
+      isPopoverVisible: {
+        type: Boolean,
+        reflect: true,
+        attribute: 'data-show',
+        converter: {
+          fromAttribute: (value) => value !== null,
+          toAttribute: (value) => (value ? 'true' : null),
+        },
+      },
     };
   }
 
@@ -115,6 +131,11 @@ export class AuroPopover extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+
+    // Prevent screen readers from announcing the custom element host as "group".
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "none");
+    }
 
     this._initializeDefaults();
 
@@ -143,10 +164,10 @@ export class AuroPopover extends LitElement {
         this._eventTarget.removeEventListener("mouseleave", this._onTriggerMouseLeave);
       }
       if (this._onTriggerFocus) {
-        this.trigger.removeEventListener("focus", this._onTriggerFocus);
+        this.trigger.removeEventListener("focusin", this._onTriggerFocus);
       }
       if (this._onTriggerBlur) {
-        this.trigger.removeEventListener("blur", this._onTriggerBlur);
+        this.trigger.removeEventListener("focusout", this._onTriggerBlur);
       }
       if (this._onTriggerKeydown) {
         this.trigger.removeEventListener("keydown", this._onTriggerKeydown);
@@ -157,7 +178,11 @@ export class AuroPopover extends LitElement {
       if (this._onSlotChange) {
         this.shadowRoot?.querySelector("slot:not([name])")?.removeEventListener("slotchange", this._onSlotChange);
       }
-      this.trigger.removeAttribute("aria-description");
+      // Remove aria-description from every element that received it in
+      // firstUpdated (focusable descendants or the trigger itself).
+      for (const target of (this._ariaDescriptionTargets || [this.trigger])) {
+        target.removeAttribute("aria-description");
+      }
 
       // Remove tabindex only if the component added it and the current value
       // still matches the value managed by the component. This avoids removing
@@ -213,67 +238,32 @@ export class AuroPopover extends LitElement {
     }
 
     // If the trigger is not keyboard accessible, make it focusable automatically.
-    // This covers native elements (e.g. <abbr>, <span>) and custom elements whose
-    // shadow DOM contains no focusable descendant (e.g. auro-icon).
-    //
-    // We skip elements that are already accessible via the tab order:
-    // - Natively focusable elements (tabIndex >= 0): <button>, <a href>, <input>, etc.
-    // - Custom elements whose shadow DOM contains a focusable descendant (e.g. auro-button
-    //   has an inner <button>) — adding tabindex to the host would create a double tab stop.
-    // - Elements where the author has explicitly set tabindex — their intent is respected.
-    //
-    // Known limitation: custom elements with a closed shadow root (mode: 'closed') cannot
-    // be inspected — shadowRoot returns null. If such an element has an internal focusable
-    // descendant and a host tabIndex of -1, tabindex="0" will be added, potentially
-    // creating a double tab stop. Elements using delegatesFocus avoid this because the
-    // browser reflects a non-negative tabIndex on the host.
-    const isNativelyFocusable = this.trigger.tabIndex >= 0;
-    const hasInternalFocus = this.trigger.shadowRoot
-      ? Boolean(this.trigger.shadowRoot.querySelector(
-          'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-        ))
-      : false;
+    // Set up aria-description so screen readers announce popover content on focus.
+    this._setupAccessibility();
 
-    if (!isNativelyFocusable && !hasInternalFocus && !this.trigger.hasAttribute("tabindex")) {
-      this.trigger.setAttribute("tabindex", "0");
-      this._addedTabIndex = true;
+    // Set up Popper instance, event listeners, and keyboard/mouse handlers.
+    this._setupEventListeners();
+
+    // If the component was initialized with data-show / isPopoverVisible
+    // already true, the updated() lifecycle won't fire for that property
+    // because it didn't change during this cycle. Sync Popper state now.
+    if (this.isPopoverVisible && this.popper) {
+      if (this.disabled) {
+        this.isPopoverVisible = false;
+      } else {
+        this.popper.show();
+        document.body.addEventListener("mouseover", this._onBodyMouseover);
+      }
     }
+  }
 
-    // Announce popover content to screen readers via aria-description (ARIA 1.3).
-    //
-    // Why not aria-describedby?
-    // The trigger (e.g. auro-button) is in light DOM; the popover content lives
-    // inside auro-popover's shadow DOM. aria-describedby ID lookup is scoped to
-    // the same shadow root, so cross-shadow references silently fail.
-    //
-    // Why not aria-live?
-    // The popover is hidden with display:none, which removes it from the
-    // accessibility tree entirely — aria-live never fires. Persistent live regions
-    // in document.body hit VoiceOver's content deduplication: identical text
-    // announced to the same region is suppressed on repeat visits.
-    //
-    // aria-description embeds the string directly on the trigger element with no
-    // ID lookup. VoiceOver recomputes it fresh on every focus event, so content
-    // is announced consistently regardless of prior visits.
-    //
-    // NOTE: aria-description is defined in the ARIA 1.3 spec. It is well-supported
-    // in modern browsers and screen readers (Chrome 92+, Firefox 92+, Safari 15.4+)
-    // but may be unfamiliar — do not replace with aria-describedby.
-    const slot = this.shadowRoot.querySelector("slot:not([name])");
-    const getSlotText = () => slot.assignedNodes({ flatten: true })
-      .map((n) => n.textContent ?? "")
-      .join(" ")
-      .replace(/\s+/g, " ")
-      .trim();
-
-    this.trigger.setAttribute("aria-description", getSlotText());
-
-    // Keep aria-description in sync if slot content changes after first render.
-    this._onSlotChange = () => {
-      this.trigger?.setAttribute("aria-description", getSlotText());
-    };
-    slot.addEventListener("slotchange", this._onSlotChange);
-
+  /**
+   * Initializes the Popper instance and attaches all event listeners
+   * for mouse, keyboard, and focus interactions on the trigger.
+   * @private
+   * @returns {void}
+   */
+  _setupEventListeners() {
     this.auroPopover = this.shadowRoot.querySelector("#popover");
     this.popper = new Popover(
       this.trigger,
@@ -286,7 +276,29 @@ export class AuroPopover extends LitElement {
     this._onTriggerMouseEnter = () => { this.toggleShow(); };
     this._onTriggerMouseLeave = () => { this.toggleHide(); };
     this._onTriggerFocus = () => { this.toggleShow(); };
-    this._onTriggerBlur = () => { this.toggleHide(); };
+    this._onTriggerBlur = (event) => {
+      // Only hide if focus leaves the trigger and popover entirely, not
+      // when moving between focusable children within the trigger or into
+      // interactive content inside the popover.
+      // Node.contains() does not cross shadow boundaries, so we walk
+      // up through shadow hosts to detect targets inside a descendant
+      // custom element's shadow root.
+      let target = event.relatedTarget;
+      let inside = false;
+
+      while (target) {
+        if (this.trigger.contains(target) || this.contains(target)) {
+          inside = true;
+          break;
+        }
+        const root = target.getRootNode();
+        target = root instanceof ShadowRoot ? root.host : null;
+      }
+
+      if (!inside) {
+        this.toggleHide();
+      }
+    };
     this._onTriggerKeydown = (event) => {
       const key = event.key.toLowerCase();
 
@@ -297,6 +309,15 @@ export class AuroPopover extends LitElement {
       }
 
       if (key === " " || key === "enter") {
+        // Only toggle from the trigger element itself, not from interactive
+        // descendants inside a wrapper trigger. focusin/focusout bubble, so
+        // keydown events from children (e.g. a link inside <div slot="trigger">)
+        // also arrive here; letting them through would interfere with the
+        // descendant's native activation (Enter on a link, Space on a button).
+        if (event.target !== this.trigger && !this._addedTabIndex) {
+          return;
+        }
+
         // Prevent page scroll for Space only on non-native triggers.
         // Native elements (button, a) handle their own Space/Enter semantics.
         if (key === " " && this._addedTabIndex) {
@@ -320,12 +341,177 @@ export class AuroPopover extends LitElement {
     // if user tabs off of trigger, then hide the popover.
     this.trigger.addEventListener("keydown", this._onTriggerKeydown);
 
-    // handle gain/loss of focus
-    this.trigger.addEventListener("focus", this._onTriggerFocus);
-    this.trigger.addEventListener("blur", this._onTriggerBlur);
+    // handle gain/loss of focus — use focusin/focusout so events bubble
+    // from focusable descendants inside wrapper triggers (e.g. <div><a>).
+    this.trigger.addEventListener("focusin", this._onTriggerFocus);
+    this.trigger.addEventListener("focusout", this._onTriggerBlur);
 
     // e.g. for a closePopover button in the popover
     this.addEventListener("hidePopover", this._onHidePopover);
+  }
+
+  /**
+   * Sets up auto-tabindex and aria-description on the trigger element.
+   *
+   * Auto-tabindex: ensures non-focusable triggers are keyboard accessible.
+   * Covers native elements (e.g. <abbr>, <span>) and custom elements whose
+   * shadow DOM contains no focusable descendant (e.g. auro-icon).
+   *
+   * We skip elements that are already accessible via the tab order:
+   * - Natively focusable elements (tabIndex >= 0): <button>, <a href>, <input>, etc.
+   * - Custom elements whose shadow DOM contains a focusable descendant (e.g. auro-button
+   *   has an inner <button>) — adding tabindex to the host would create a double tab stop.
+   * - Elements where the author has explicitly set tabindex — their intent is respected.
+   *
+   * Known limitation: custom elements with a closed shadow root (mode: 'closed') cannot
+   * be inspected — shadowRoot returns null. If such an element has an internal focusable
+   * descendant and a host tabIndex of -1, tabindex="0" will be added, potentially
+   * creating a double tab stop. Elements using delegatesFocus avoid this because the
+   * browser reflects a non-negative tabIndex on the host.
+   *
+   * aria-description (ARIA 1.3): embeds the popover content string directly on
+   * the trigger so screen readers announce it on focus. Preferred over
+   * aria-describedby (cross-shadow ID lookup fails) and aria-live (display:none
+   * removes the region from the accessibility tree).
+   *
+   * @private
+   * @returns {void}
+   */
+  _setupAccessibility() {
+    const isNativelyFocusable = this.trigger.tabIndex >= 0;
+    const focusableSelector =
+      'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex^="-"]), [contenteditable]:not([contenteditable="false"]), summary, iframe, audio[controls], video[controls]';
+
+    // CSS selectors alone can match elements removed from the tab order
+    // (e.g. <button tabindex="-1">) or hidden/inert descendants. Verify
+    // actual keyboard reachability before treating a match as focusable.
+    // closest() does not cross shadow boundaries, so we also walk up
+    // through shadow hosts to catch hidden/inert ancestors in the light DOM.
+    const isReachable = (el) => {
+      if (el.tabIndex < 0) return false;
+      let node = el;
+      while (node) {
+        if (node.closest('[hidden], [inert]')) return false;
+        const root = node.getRootNode();
+        node = root instanceof ShadowRoot ? root.host : null;
+      }
+      return true;
+    };
+
+    // Check light DOM children for focusable elements.
+    let hasInternalFocus = [...this.trigger.querySelectorAll(focusableSelector)].some(isReachable);
+
+    // Also check light DOM custom element descendants whose shadow DOM
+    // contains focusable content. querySelector cannot reach into shadow
+    // roots, so custom elements like auro-button inside a wrapper trigger
+    // would otherwise be missed (e.g. <div><auro-button></auro-button></div>).
+    if (!hasInternalFocus) {
+      const descendants = this.trigger.querySelectorAll('*');
+
+      for (const child of descendants) {
+        if (child.localName.includes('-') && (child.tabIndex >= 0 ||
+            (child.shadowRoot && [...child.shadowRoot.querySelectorAll(focusableSelector)].some(isReachable)))) {
+          hasInternalFocus = true;
+          break;
+        }
+      }
+    }
+
+    // For custom elements used directly as the trigger (not wrapped),
+    // also check the trigger's own shadow DOM for focusable descendants.
+    // If the shadow root is inaccessible (closed mode or not yet upgraded),
+    // we cannot inspect it — the element will receive tabindex if it is not
+    // otherwise focusable. This is a known limitation documented above.
+    if (!hasInternalFocus && this.trigger.localName.includes('-') && this.trigger.shadowRoot) {
+      hasInternalFocus = [...this.trigger.shadowRoot.querySelectorAll(focusableSelector)].some(isReachable);
+    }
+
+    if (!isNativelyFocusable && !hasInternalFocus && !this.trigger.hasAttribute("tabindex")) {
+      this.trigger.setAttribute("tabindex", "0");
+      this._addedTabIndex = true;
+    }
+
+    // Set up aria-description on the appropriate focusable element(s).
+    // NOTE: aria-description is defined in the ARIA 1.3 spec. It is well-supported
+    // in modern browsers and screen readers (Chrome 92+, Firefox 92+, Safari 15.4+)
+    // but may be unfamiliar — do not replace with aria-describedby.
+    const slot = this.shadowRoot.querySelector("slot:not([name])");
+    const getSlotText = () => slot.assignedNodes({ flatten: true })
+      .map((n) => n.textContent ?? "")
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    // Determine which elements should receive aria-description.
+    // When the trigger is a non-focusable wrapper around focusable content
+    // (e.g. <div><a href="#">link</a></div>), the description must go on
+    // every element that can actually receive focus so screen readers announce it.
+    this._ariaDescriptionTargets = [];
+
+    if (!isNativelyFocusable && hasInternalFocus) {
+      // Gather all keyboard-reachable light DOM descendants.
+      const nativeMatches = [...this.trigger.querySelectorAll(focusableSelector)].filter(isReachable);
+
+      this._ariaDescriptionTargets.push(...nativeMatches);
+
+      // Check custom element descendants whose shadow DOM is focusable.
+      const allDescendants = this.trigger.querySelectorAll('*');
+
+      for (const child of allDescendants) {
+        if (!child.localName.includes('-')) continue;
+        // Skip if already matched by the native selector (e.g. has tabindex attribute).
+        if (nativeMatches.includes(child)) continue;
+
+        if (child.tabIndex >= 0) {
+          // Host is keyboard-reachable (delegatesFocus or explicit tabindex).
+          this._ariaDescriptionTargets.push(child);
+        } else if (child.shadowRoot) {
+          // Host is not keyboard-reachable; focus goes to internal elements.
+          // Set description directly on the shadow DOM focusable controls.
+          const shadowFocusable = [...child.shadowRoot.querySelectorAll(focusableSelector)].filter(isReachable);
+
+          for (const el of shadowFocusable) {
+            this._ariaDescriptionTargets.push(el);
+          }
+        }
+      }
+
+      if (this._ariaDescriptionTargets.length === 0) {
+        // The trigger itself is a custom element with focusable shadow content
+        // (e.g. mock-focusable, auro-button used directly as trigger).
+        // Light DOM searches found nothing; add the shadow focusable controls
+        // so the description is announced when focus lands inside the shadow root.
+        if (this.trigger.localName.includes('-') && this.trigger.shadowRoot) {
+          const shadowFocusable = [...this.trigger.shadowRoot.querySelectorAll(focusableSelector)].filter(isReachable);
+
+          this._ariaDescriptionTargets.push(...shadowFocusable);
+        }
+
+        // Final fallback: if no focusable targets were discovered, put the
+        // description on the trigger host itself.
+        if (this._ariaDescriptionTargets.length === 0) {
+          this._ariaDescriptionTargets.push(this.trigger);
+        }
+      }
+    } else {
+      this._ariaDescriptionTargets.push(this.trigger);
+    }
+
+    const description = getSlotText();
+
+    for (const target of this._ariaDescriptionTargets) {
+      target.setAttribute("aria-description", description);
+    }
+
+    // Keep aria-description in sync if slot content changes after first render.
+    this._onSlotChange = () => {
+      const text = getSlotText();
+
+      for (const target of this._ariaDescriptionTargets) {
+        target?.setAttribute("aria-description", text);
+      }
+    };
+    slot.addEventListener("slotchange", this._onSlotChange);
   }
 
   /**
@@ -351,14 +537,6 @@ export class AuroPopover extends LitElement {
    */
   toggleHide() {
     this.isPopoverVisible = false;
-    this.removeAttribute("data-show");
-    if (this._onBodyMouseover) {
-      document.body.removeEventListener("mouseover", this._onBodyMouseover);
-    }
-    if (!this.popper) {
-      return;
-    }
-    this.popper.hide();
   }
 
   /**
@@ -367,14 +545,10 @@ export class AuroPopover extends LitElement {
    * @returns {void} Fires an update lifecycle.
    */
   toggleShow() {
-    if (!this.popper) {
+    if (!this.popper || this.disabled) {
       return;
     }
-    this.popper.show();
     this.isPopoverVisible = true;
-    this.setAttribute("data-show", "true");
-
-    document.body.addEventListener("mouseover", this._onBodyMouseover);
   }
 
   /**
@@ -396,17 +570,53 @@ export class AuroPopover extends LitElement {
       // preventOverflow modifier, which expects an Element.
       this.popper.boundaryElement = this.popper.setBoundary(this.boundary);
     }
+
+    // Sync Popper positioning and body listeners whenever visibility changes.
+    // This runs after Lit has reflected the data-show attribute to the host,
+    // so the CSS that controls .popover display is already applied and Popper
+    // can measure a visible element. Centralising the side effects here also
+    // guards against external data-show / isPopoverVisible changes that would
+    // otherwise bypass toggleShow()/toggleHide().
+    if (changedProperties.has("isPopoverVisible") && this.popper) {
+      if (this.isPopoverVisible) {
+        // Reject visibility when disabled — force back to false so the next
+        // updated() cycle runs the hide/cleanup path instead.
+        if (this.disabled) {
+          this.isPopoverVisible = false;
+          return;
+        }
+        this.popper.show();
+        document.body.addEventListener("mouseover", this._onBodyMouseover);
+      } else {
+        if (this._onBodyMouseover) {
+          document.body.removeEventListener("mouseover", this._onBodyMouseover);
+        }
+        this.popper.hide();
+      }
+    }
+
+    // If disabled becomes true while the popover is visible, force-hide so
+    // aria-hidden, the body mouseover listener, and Popper stay in sync with
+    // the CSS that hides the popover via :host([disabled]).
+    if (changedProperties.has("disabled") && this.disabled && this.isPopoverVisible) {
+      this.isPopoverVisible = false;
+    }
   }
 
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     return html`
-      <div id="popover" class="popover util_insetLg body-default" part="popover">
+      <div
+      id="popover"
+      class="popover util_insetLg body-default"
+      part="popover"
+      role="tooltip"
+      aria-hidden="${this.isPopoverVisible ? 'false' : 'true'}">
         <div id="arrow" class="arrow" data-popper-arrow></div>
-        <span role="tooltip"><slot></slot></span>
+        <slot></slot>
       </div>
 
-      <span>
+      <span role="presentation">
         <slot name="trigger" data-trigger-placement="${this.placement}"></slot>
       </span>
     `;

--- a/test/auro-popover.test.js
+++ b/test/auro-popover.test.js
@@ -21,17 +21,17 @@ async function getFixture() {
 }
 
 /**
- * Assert that the popover is currently shown (data-show attribute present).
+ * Assert that the popover is currently shown.
  */
 function expectPopoverShown(el) {
-  expect(el.hasAttribute("data-show")).to.equal(true);
+  expect(el.isPopoverVisible).to.equal(true);
 }
 
 /**
- * Assert that the popover is currently hidden (data-show attribute absent).
+ * Assert that the popover is currently hidden.
  */
 function expectPopoverHidden(el) {
-  expect(el.hasAttribute("data-show")).to.equal(false);
+  expect(el.isPopoverVisible).to.equal(false);
 }
 
 // ---------------------------------------------------------------------------
@@ -358,6 +358,88 @@ describe("auro-popover — auto-tabindex", () => {
     expect(trigger.hasAttribute("tabindex")).to.be.false;
   });
 
+  it("does not add tabindex to element with focusable light DOM child", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><a href="#">link trigger</a></div>
+      </auro-popover>
+    `);
+    const trigger = el.querySelector("div");
+
+    expect(trigger.hasAttribute("tabindex")).to.be.false;
+  });
+
+  it("shows popover when focusable light DOM child receives focus", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><a href="#">link trigger</a></div>
+      </auro-popover>
+    `);
+    const anchor = el.querySelector("a");
+
+    expectPopoverHidden(el);
+    anchor.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expectPopoverShown(el);
+  });
+
+  it("sets aria-description on focusable light DOM child, not wrapper", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><a href="#">link trigger</a></div>
+      </auro-popover>
+    `);
+    const wrapper = el.querySelector("div");
+    const anchor = el.querySelector("a");
+
+    expect(wrapper.hasAttribute("aria-description")).to.be.false;
+    expect(anchor.getAttribute("aria-description")).to.equal("tooltip text");
+  });
+
+  it("sets aria-description on shadow DOM focusable element inside custom-element trigger", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <mock-focusable slot="trigger"></mock-focusable>
+      </auro-popover>
+    `);
+    const trigger = el.querySelector("mock-focusable");
+    const innerButton = trigger.shadowRoot.querySelector("button");
+
+    expect(trigger.hasAttribute("aria-description")).to.be.false;
+    expect(innerButton.getAttribute("aria-description")).to.equal("tooltip text");
+  });
+
+  it("does not add tabindex to wrapper around custom element with focusable shadow DOM", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><mock-focusable></mock-focusable></div>
+      </auro-popover>
+    `);
+    const wrapper = el.querySelector("div");
+
+    expect(wrapper.hasAttribute("tabindex")).to.be.false;
+  });
+
+  it("shows popover when custom element child in wrapper receives focus", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><mock-focusable></mock-focusable></div>
+      </auro-popover>
+    `);
+    const customChild = el.querySelector("mock-focusable");
+    const shadowButton = customChild.shadowRoot.querySelector("button");
+
+    expectPopoverHidden(el);
+    // Dispatch from the actual shadow DOM control to test real focus path.
+    shadowButton.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
+    expectPopoverShown(el);
+  });
+
   it("removes auto-added tabindex from trigger on disconnect", async () => {
     const container = await fixture(html`
       <div>
@@ -393,43 +475,130 @@ describe("auro-popover — auto-tabindex", () => {
 
     expect(abbr.getAttribute("tabindex")).to.equal("0");
   });
+
+  it("adds tabindex when native child has tabindex=-1 (not keyboard-reachable)", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><button tabindex="-1">unreachable</button></div>
+      </auro-popover>
+    `);
+    const wrapper = el.querySelector("div");
+
+    expect(wrapper.getAttribute("tabindex")).to.equal("0");
+  });
+
+  it("adds tabindex when child is hidden", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><button hidden>hidden btn</button></div>
+      </auro-popover>
+    `);
+    const wrapper = el.querySelector("div");
+
+    expect(wrapper.getAttribute("tabindex")).to.equal("0");
+  });
+
+  it("adds tabindex when child is inside inert subtree", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><span inert><a href="#">inert link</a></span></div>
+      </auro-popover>
+    `);
+    const wrapper = el.querySelector("div");
+
+    expect(wrapper.getAttribute("tabindex")).to.equal("0");
+  });
 });
 
 // ---------------------------------------------------------------------------
 // Shadow DOM structure
 // ---------------------------------------------------------------------------
 // Verifies the required shadow DOM shape is present and correct. Guards
-// against regressions where refactoring might accidentally remove role=tooltip,
-// re-introduce aria-live (non-functional with display:none), or add
-// aria-labelledby back to the tooltip span (was previously incorrectly
-// pointing at the trigger).
+// against regressions where refactoring might accidentally remove the
+// aria-hidden attribute, re-introduce aria-live (non-functional with
+// display:none), or break the presentation role on the trigger wrapper.
 
 describe("auro-popover — shadow DOM structure", () => {
-  it("tooltip span has role='tooltip' wrapping the default slot", async () => {
+  it("popover content is delivered via slot inside the popover div", async () => {
     const el = await fixture(html`
       <auro-popover>
         tooltip text
         <button slot="trigger">trigger text</button>
       </auro-popover>
     `);
-    const tooltipSpan = el.shadowRoot.querySelector('span[role="tooltip"]');
+    const popoverDiv = el.shadowRoot.querySelector('#popover');
+    const slot = popoverDiv.querySelector('slot:not([name])');
 
-    expect(tooltipSpan, 'Expected a <span role="tooltip"> in shadow DOM').to.exist;
-    expect(tooltipSpan.querySelector('slot')).to.exist;
-  });
-
-  it("popover content is delivered via slot, not hardcoded in shadow DOM", async () => {
-    const el = await fixture(html`
-      <auro-popover>
-        tooltip text
-        <button slot="trigger">trigger text</button>
-      </auro-popover>
-    `);
-    const slot = el.shadowRoot.querySelector('span[role="tooltip"] slot');
+    expect(slot, 'Expected a default slot inside #popover').to.exist;
     const assignedText = slot.assignedNodes({ flatten: true }).map((n) => n.textContent).join('').trim();
-
     expect(assignedText).to.equal('tooltip text');
     expect(el.shadowRoot.innerHTML).to.not.include('tooltip text');
+  });
+
+  it("popover div has aria-hidden='true'", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <button slot="trigger">trigger text</button>
+      </auro-popover>
+    `);
+    const popoverDiv = el.shadowRoot.querySelector('#popover');
+
+    expect(popoverDiv.getAttribute('aria-hidden')).to.equal('true');
+  });
+
+  it("popover div aria-hidden syncs with visibility", async () => {
+    const el = await getFixture();
+
+    const popoverDiv = el.shadowRoot.querySelector('#popover');
+    expect(popoverDiv.getAttribute('aria-hidden')).to.equal('true');
+
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    expectPopoverShown(el);
+    await el.updateComplete;
+    expect(popoverDiv.getAttribute('aria-hidden')).to.equal('false');
+
+    el.dispatchEvent(new MouseEvent("mouseleave"));
+    expectPopoverHidden(el);
+    await el.updateComplete;
+    expect(popoverDiv.getAttribute('aria-hidden')).to.equal('true');
+  });
+
+  it("trigger slot wrapper has role='presentation'", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <button slot="trigger">trigger text</button>
+      </auro-popover>
+    `);
+    const triggerWrapper = el.shadowRoot.querySelector('slot[name="trigger"]').parentElement;
+
+    expect(triggerWrapper.getAttribute('role')).to.equal('presentation');
+  });
+
+  it("host element has role='none'", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <button slot="trigger">trigger text</button>
+      </auro-popover>
+    `);
+
+    expect(el.getAttribute('role')).to.equal('none');
+  });
+
+  it("does not override author-set role on host", async () => {
+    const el = await fixture(html`
+      <auro-popover role="region">
+        tooltip text
+        <button slot="trigger">trigger text</button>
+      </auro-popover>
+    `);
+
+    expect(el.getAttribute('role')).to.equal('region');
   });
 
   it("shadow DOM does not contain an aria-live attribute", async () => {
@@ -444,16 +613,58 @@ describe("auro-popover — shadow DOM structure", () => {
     expect(liveRegion, 'aria-live must not exist in shadow DOM — it does not fire on display:none elements').to.not.exist;
   });
 
-  it("tooltip span does not have aria-labelledby", async () => {
+  it("popover div has role='tooltip'", async () => {
     const el = await fixture(html`
       <auro-popover>
         tooltip text
         <button slot="trigger">trigger text</button>
       </auro-popover>
     `);
-    const tooltipSpan = el.shadowRoot.querySelector('span[role="tooltip"]');
+    const popoverDiv = el.shadowRoot.querySelector('#popover');
 
-    expect(tooltipSpan.hasAttribute('aria-labelledby'), 'aria-labelledby must not be on the tooltip span — it incorrectly pointed back at the trigger').to.be.false;
+    expect(popoverDiv.getAttribute('role')).to.equal('tooltip');
+  });
+
+  it("role='tooltip' is maintained after popover shows", async () => {
+    const el = await getFixture();
+    const popoverDiv = el.shadowRoot.querySelector('#popover');
+
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    await el.updateComplete;
+
+    expect(popoverDiv.getAttribute('role')).to.equal('tooltip');
+  });
+
+  it("role='tooltip' is maintained after popover hides", async () => {
+    const el = await getFixture();
+    const popoverDiv = el.shadowRoot.querySelector('#popover');
+
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    await el.updateComplete;
+    el.dispatchEvent(new MouseEvent("mouseleave"));
+    await el.updateComplete;
+
+    expect(popoverDiv.getAttribute('role')).to.equal('tooltip');
+  });
+
+  it("data-show attribute value is 'true' when popover is visible", async () => {
+    const el = await getFixture();
+
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    await el.updateComplete;
+
+    expect(el.getAttribute('data-show')).to.equal('true');
+  });
+
+  it("data-show attribute is removed when popover is hidden", async () => {
+    const el = await getFixture();
+
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    await el.updateComplete;
+    el.dispatchEvent(new MouseEvent("mouseleave"));
+    await el.updateComplete;
+
+    expect(el.hasAttribute('data-show')).to.be.false;
   });
 });
 
@@ -461,31 +672,10 @@ describe("auro-popover — shadow DOM structure", () => {
 // ARIA structure integrity
 // ---------------------------------------------------------------------------
 // Verifies that ARIA attributes remain correct through show and hide cycles.
-// Ensures visibility state changes do not corrupt the role=tooltip contract
+// Ensures visibility state changes do not corrupt the aria-hidden contract
 // or the aria-description value set on the trigger.
 
 describe("auro-popover — ARIA structure integrity", () => {
-  it("role='tooltip' is maintained after popover shows", async () => {
-    const el = await getFixture();
-
-    el.dispatchEvent(new MouseEvent("mouseenter"));
-
-    const tooltipSpan = el.shadowRoot.querySelector('span[role="tooltip"]');
-    expect(tooltipSpan).to.exist;
-    expect(tooltipSpan.getAttribute('role')).to.equal('tooltip');
-  });
-
-  it("role='tooltip' is maintained after popover hides", async () => {
-    const el = await getFixture();
-
-    el.dispatchEvent(new MouseEvent("mouseenter"));
-    el.dispatchEvent(new MouseEvent("mouseleave"));
-
-    const tooltipSpan = el.shadowRoot.querySelector('span[role="tooltip"]');
-    expect(tooltipSpan).to.exist;
-    expect(tooltipSpan.getAttribute('role')).to.equal('tooltip');
-  });
-
   it("aria-description on trigger is correct after a show and hide cycle", async () => {
     const el = await fixture(html`
       <auro-popover>
@@ -515,6 +705,7 @@ describe("auro-popover — triggerUpdate", () => {
     const el = await getFixture();
 
     el.dispatchEvent(new MouseEvent("mouseenter"));
+    await el.updateComplete;
 
     expect(() => el.popper.triggerUpdate()).to.not.throw();
   });
@@ -531,6 +722,7 @@ describe("auro-popover — handleMouseoverEvent", () => {
     const el = await getFixture();
 
     el.dispatchEvent(new MouseEvent("mouseenter"));
+    await el.updateComplete;
     expectPopoverShown(el);
 
     document.body.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, composed: true }));
@@ -628,7 +820,7 @@ describe("auro-popover — visibility via keyboard", () => {
     const el = await getFixture();
 
     expectPopoverHidden(el);
-    el.trigger.dispatchEvent(new Event("focus"));
+    el.trigger.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
     expectPopoverShown(el);
     el.trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expectPopoverHidden(el);
@@ -646,7 +838,7 @@ describe("auro-popover — visibility via keyboard", () => {
     const el = await getFixture();
 
     expectPopoverHidden(el);
-    el.trigger.dispatchEvent(new Event("focus"));
+    el.trigger.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
     expectPopoverShown(el);
     el.trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     expectPopoverHidden(el);
@@ -670,6 +862,118 @@ describe("auro-popover — visibility via touch", () => {
     expectPopoverShown(el);
     el.dispatchEvent(new Event("touchstart"));
     expectPopoverHidden(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Disabled behavior
+// ---------------------------------------------------------------------------
+// Verifies the popover does not show when the disabled attribute is set,
+// regardless of interaction method (hover, focus, keyboard toggle).
+
+describe("auro-popover — disabled behavior", () => {
+  it("does not show popover on hover when disabled", async () => {
+    const el = await fixture(html`
+      <auro-popover disabled>
+        tooltip text
+        <auro-button slot="trigger">trigger text</auro-button>
+      </auro-popover>
+    `);
+
+    expectPopoverHidden(el);
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    expectPopoverHidden(el);
+  });
+
+  it("does not show popover on focus when disabled", async () => {
+    const el = await fixture(html`
+      <auro-popover disabled>
+        tooltip text
+        <auro-button slot="trigger">trigger text</auro-button>
+      </auro-popover>
+    `);
+
+    expectPopoverHidden(el);
+    el.trigger.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expectPopoverHidden(el);
+  });
+
+  it("does not show popover on Space/Enter when disabled", async () => {
+    const el = await fixture(html`
+      <auro-popover disabled>
+        tooltip text
+        <auro-button slot="trigger">trigger text</auro-button>
+      </auro-popover>
+    `);
+
+    expectPopoverHidden(el);
+    el.trigger.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
+    expectPopoverHidden(el);
+    el.trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expectPopoverHidden(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus within shadow DOM trigger
+// ---------------------------------------------------------------------------
+// Verifies the popover stays visible when focus moves between elements
+// inside a custom element trigger's shadow DOM, since Node.contains()
+// does not cross shadow boundaries.
+
+describe("auro-popover — focus within shadow DOM trigger", () => {
+  it("keeps popover visible when focus moves within trigger shadow DOM", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text
+        <div slot="trigger"><mock-focusable></mock-focusable></div>
+      </auro-popover>
+    `);
+    const customChild = el.querySelector("mock-focusable");
+    const shadowButton = customChild.shadowRoot.querySelector("button");
+
+    // Show via focusin from shadow DOM button.
+    shadowButton.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
+    expectPopoverShown(el);
+
+    // Simulate focus moving from one shadow element to another within the trigger.
+    // relatedTarget is the shadow button — still inside the trigger's subtree.
+    el.trigger.dispatchEvent(new FocusEvent("focusout", {
+      bubbles: true,
+      composed: true,
+      relatedTarget: shadowButton,
+    }));
+    expectPopoverShown(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus moving from trigger into popover content
+// ---------------------------------------------------------------------------
+// Verifies the popover stays visible when focus moves from the trigger
+// into interactive content inside the popover (e.g. a link).
+
+describe("auro-popover — focus into popover content", () => {
+  it("keeps popover visible when focus moves from trigger to a link inside the popover", async () => {
+    const el = await fixture(html`
+      <auro-popover>
+        tooltip text <a href="#">learn more</a>
+        <button slot="trigger">trigger text</button>
+      </auro-popover>
+    `);
+    const trigger = el.querySelector("button");
+    const link = el.querySelector("a");
+
+    // Show via focusin on trigger.
+    trigger.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expectPopoverShown(el);
+
+    // Simulate focus leaving the trigger and landing on the popover link.
+    trigger.dispatchEvent(new FocusEvent("focusout", {
+      bubbles: true,
+      relatedTarget: link,
+    }));
+    expectPopoverShown(el);
   });
 });
 
@@ -718,7 +1022,7 @@ describe("auro-popover — event listener cleanup", () => {
     container.removeChild(popover);
 
     // focus on the trigger should not show the popover after disconnect
-    trigger.dispatchEvent(new Event("focus"));
+    trigger.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
 
     expectPopoverHidden(popover);
   });
@@ -767,6 +1071,7 @@ describe("auro-popover — event listener cleanup", () => {
 
     // Show the popover to create the Popper.js instance
     popover.dispatchEvent(new MouseEvent("mouseenter"));
+    await popover.updateComplete;
 
     container.removeChild(popover);
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-popover/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve auro-popover accessibility by adjusting host and trigger roles and ensuring popover content remains hidden from screen readers when not active.

Bug Fixes:
- Prevent automatic tabindex from being added when the trigger has focusable light DOM children, avoiding double tab stops.

Enhancements:
- Set a default role='none' on the auro-popover host while preserving any author-defined role to prevent unwanted group announcements by screen readers.
- Update popover markup to use an aria-hidden popover container and a presentational wrapper for the trigger slot, simplifying the ARIA structure for better screenreader behavior.

Tests:
- Add and update unit tests to cover new tabindex behavior, popover DOM structure, and ARIA attributes including host role handling and aria-hidden consistency.